### PR TITLE
Streamline CI/CD Workflows and Update Docker Security Scanning

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -1,11 +1,9 @@
-name: Docker Build
+name: Docker Push
 
 on:
   push:
     branches:
       - "master"
-  pull_request:
-    branches: [ "master" ]
 
 jobs:
   build:

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -14,13 +14,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Run Trivy vulnerability scanner for Backend
-        uses: aquasecurity/trivy-action@0.29.0
+      - name: Build the Docker Image
+        uses: docker/build-push-action@v6
         with:
-          image-ref: '${{ vars.DOCKERHUB_USERNAME }}/jp-morphemes-extractor:latest'
-          format: 'table'
+          push: false
+          tags: ${{ vars.DOCKERHUB_USERNAME }}/jp-morphemes-extractor:latest
 
-      - name: Run Trivy vulnerability scanner for Frontend
+      - name: Run Trivy vulnerability scanner for Docker Image
         uses: aquasecurity/trivy-action@0.29.0
         with:
           image-ref: '${{ vars.DOCKERHUB_USERNAME }}/jp-morphemes-extractor:latest'


### PR DESCRIPTION
Description:
## Changes
### docker-push.yml
- Renamed workflow from "Docker Build" to "Docker Push" for clarity
- Removed redundant PR trigger for master branch
- Workflow now only runs on push to master

### trivy-scan.yml
- Added explicit Docker image build step before security scanning
- Consolidated duplicate Trivy scans into a single scan
- Updated to use latest docker/build-push-action@v6
